### PR TITLE
New Implementation of State Management Experimentation

### DIFF
--- a/pyfyre/core/exceptions.py
+++ b/pyfyre/core/exceptions.py
@@ -1,9 +1,9 @@
 from pyfyre.widgets.widget import Widget
 
-class BaseException:
-    def __init__(self, msg, e):
+class UIBaseException:
+    def __init__(self, msg, e=None):
         self.msg = msg
-        self.e = e
+        self.e = e if e else msg
 
     def dom(self):
         print(f"Uncaught exception: {self.e}")
@@ -23,4 +23,5 @@ class BaseException:
             
             return element
 
-class RenderError(BaseException): ...
+class RenderError(UIBaseException): ...
+class InvalidController(BaseException): ...

--- a/pyfyre/widgets/__init__.py
+++ b/pyfyre/widgets/__init__.py
@@ -3,11 +3,12 @@ from pyfyre.widgets.container import Container
 from pyfyre.widgets.image import Image
 from pyfyre.widgets.link import Link
 from pyfyre.widgets.listbuilder import ListBuilder
-from pyfyre.widgets.states import UsesState
+from pyfyre.widgets.states import UsesState, State
 from pyfyre.widgets.text import Text
+from pyfyre.widgets.textinput import TextInput, TextInputController
 
 __all__ = [
     'Button', 'Container', 'Image',
     'Link', 'ListBuilder', 'UsesState',
-    'Text'
+    'Text', 'State', 'TextInput', 'TextInputController'
 ]

--- a/pyfyre/widgets/states.py
+++ b/pyfyre/widgets/states.py
@@ -1,6 +1,7 @@
 """PyFyre States"""
 
 from pyfyre.globals import Globals
+from pyfyre.globals.events import Events
 from pyfyre.widgets.widget import Widget
 from pyfyre.core.exceptions import RenderError
 
@@ -61,3 +62,19 @@ class UsesState:
         self.domElement.remove()
         self.domElement = self.dom()
         parentNode.appendChild(self.domElement)
+
+class State:
+    def __init__(self, value):
+        self.value = value
+
+        # Adds a new global event for when this state
+        # change, every listener of this State will be
+        # fired and will be adapt to new state changes.
+        Events.add(f"state-{id(self)}")
+
+    def setValue(self, newValue):
+        self.value = newValue
+        
+        # When this state has detected a change, all
+        # listeners of this State will adapt to state change.
+        Events.broadcast(f"state-{id(self)}")

--- a/pyfyre/widgets/text.py
+++ b/pyfyre/widgets/text.py
@@ -1,4 +1,6 @@
+from pyfyre.widgets.states import State
 from pyfyre.widgets.widget import Widget
+from pyfyre.globals.events import Events
 
 class Text(Widget):
     """Creates a Text widget.
@@ -17,6 +19,18 @@ class Text(Widget):
     
     def dom(self):
         element = super().dom()
+
+        # If the textContent is a State object, create a listener to the
+        # global state event, for when if the state change, this widget
+        # will automatically adapt to new state changes and updates the DOM.
+        if isinstance(self.textContent, State):
+            def stateChange():
+                self.element.textContent = self.textContent.value
+
+            Events.addListener(f"state-{id(self.textContent)}", stateChange)
+            Events.broadcast(f"state-{id(self.textContent)}") # Broadcast it to adapt the initial value of the State.
+            return element
+
         element.textContent = self.textContent
         
         return element

--- a/pyfyre/widgets/textinput.py
+++ b/pyfyre/widgets/textinput.py
@@ -1,0 +1,67 @@
+from pyfyre.core.exceptions import InvalidController
+from pyfyre.widgets.widget import Widget
+
+class TextInput(Widget):
+    """Creates a Text input widget.
+
+    Parameters
+    ----------
+    onInput : method
+        Method passed on this parameter will be fired automatically
+        when the user puts input to this widget.
+    """
+    
+    def __init__(self, controller=None, onInput=None, className="", props: dict=None):
+        super().__init__("input", className=className, props=props)
+        self.controller = controller
+        self.onInput = onInput
+    
+    def dom(self):
+        element = super().dom()
+
+        if self.controller:
+            self.controller.callback(self)
+        
+        if self.onInput:
+            
+            def wrapper(event):
+                self.onInput(element.value)
+                
+            element.bind('input', wrapper)
+        
+        return element
+
+class TextInputController:
+    def __init__(self):
+        self.this = None
+        
+        # TextInput attributes
+        self.readOnly = False
+        self.disabled = False
+
+    def changeAttribute(self, readOnly=False, disabled=False):
+        if not self.this or not isinstance(self.this, TextInput):
+            raise InvalidController("Looks like you haven't called this controller as a parameter controller of TextInput or you provided an invalid controller.")
+
+        self.readOnly = readOnly
+        self.disabled = disabled
+
+        if self.readOnly:
+            self.this.element.attrs['readonly'] = None
+        else:
+            if 'readonly' in self.this.element.attrs:
+                del self.this.element.attrs['readonly']
+
+        if self.disabled:
+            self.this.element.attrs['disabled'] = None
+        else:
+            if 'disabled' in self.this.element.attrs:
+                del self.this.element.attrs['disabled']
+
+    def callback(self, this: TextInput):
+        """
+        This is called when this TextInputController object
+        is passed as a parameter Controller of TextInput widget.
+        """
+        self.this = this
+        


### PR DESCRIPTION
This PR is an experimentation of a new State Management implementation as well as the TextInput and TextController

The cause of this experimentation is the major state management bug seen when implementing the TextInput widget. When implementing the `onInput` method fired when the input value changed, a major bug is seen.

For the UI to apply the changes, the `self.update()` should be called then the Component will rerender as well as the TextInput. When that happens, the state of the TextInput widget reinstantiate along with its value even the value is outside the `build` method or even the value is stored in another object (or the State object) (It's also strange to me).

If you want to contribute to this experimentation, kindly pull the new branch called `state-management` and if you have anything changed regarding this, PR it to `state-management` branch.