### PR TITLE
Delegate the return of Widget.build for the Element

### DIFF
--- a/pyfyre/nodes/base.py
+++ b/pyfyre/nodes/base.py
@@ -41,7 +41,9 @@ class Element(Node):
 		self.tag_name = tag_name
 		self.children: List[Node] = []
 		self.style = Style.from_styles(styles) if styles else None
+		self.states = states or []
 		self.attrs = attrs or {}
+		self._styles = styles
 		self._children_builder = children
 		
 		def update_style_attr() -> None:
@@ -60,9 +62,8 @@ class Element(Node):
 			self.style.add_listener(update_style_attr)
 			update_style_attr()
 		
-		if states:
-			for state in states:
-				state.add_listener(self.update_dom)
+		for state in self.states:
+			state.add_listener(self.update_dom)
 		
 		super().__init__()
 	

--- a/pyfyre/nodes/futures.py
+++ b/pyfyre/nodes/futures.py
@@ -18,7 +18,7 @@ class FutureElement(Element):
 		*,
 		styles: Optional[List[Style]] = None,
 		states: Optional[List[State[Any]]] = None,
-		attrs: Optional[Dict[str, str]] = None,
+		attrs: Optional[Dict[str, str]] = None
 	) -> None:
 		self._is_done = False
 		self._is_cancelled = False

--- a/pyfyre/nodes/widgets.py
+++ b/pyfyre/nodes/widgets.py
@@ -7,15 +7,11 @@ from typing import Optional, Dict, List, Callable, Awaitable, Any
 
 
 class Widget(Element, ABC):
-	def __init__(
-		self, *,
-		styles: Optional[List[Style]] = None,
-		states: Optional[List[State[Any]]] = None,
-		attrs: Optional[Dict[str, str]] = None
-	) -> None:
+	def __init__(self) -> None:
+		el = self.build()
 		super().__init__(
-			"div", lambda: [self.build()],
-			styles=styles, states=states, attrs=attrs
+			el.tag_name, el._children_builder,
+			styles=el._styles, states=el.states, attrs=el.attrs
 		)
 	
 	@abstractmethod
@@ -26,6 +22,7 @@ class Widget(Element, ABC):
 class FutureWidget(FutureElement, ABC):
 	def __init__(
 		self, *,
+		tag_name: str = "div",
 		styles: Optional[List[Style]] = None,
 		states: Optional[List[State[Any]]] = None,
 		attrs: Optional[Dict[str, str]] = None
@@ -34,7 +31,7 @@ class FutureWidget(FutureElement, ABC):
 			return [await self.build()]
 		
 		super().__init__(
-			"div", typing.cast(Callable[[], Awaitable[List[Node]]], build),
+			tag_name, typing.cast(Callable[[], Awaitable[List[Node]]], build),
 			styles=styles, states=states, attrs=attrs
 		)
 	

--- a/pyfyre/nodes/widgets.py
+++ b/pyfyre/nodes/widgets.py
@@ -1,3 +1,4 @@
+import sys
 import typing
 from pyfyre.styles import Style
 from pyfyre.states import State
@@ -8,7 +9,12 @@ from typing import Optional, Dict, List, Callable, Awaitable, Any
 
 class Widget(Element, ABC):
 	def __init__(self) -> None:
-		el = self.build()
+		try:
+			el = self.build()
+		except BaseException:
+			error_children = self.on_build_error(*sys.exc_info())
+			el = Element("div", lambda: error_children)
+		
 		super().__init__(
 			el.tag_name, el._children_builder,
 			styles=el._styles, states=el.states, attrs=el.attrs

--- a/pyfyre/presets/errors.py
+++ b/pyfyre/presets/errors.py
@@ -30,7 +30,8 @@ class DebugError(Element):
 					"p",
 					lambda: [Element("pre", lambda: [Text(exc_traceback)])],
 					styles=[Style(
-						background_color="black", color="white", padding="1px 15px"
+						background_color="black", color="white",
+						padding="1px 15px", font_size="0.9rem", font_weight="normal"
 					)]
 				)
 			],


### PR DESCRIPTION
The `Widget` now delegates the return `Element` of the `Widget.build` method. Also, add a `tag_name` parameter on the `FutureWidget` class.