### PR TITLE
unofficial update of livereload until official get updated

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 brython==3.10.7
-livereload==2.6.3
+https://github.com/nacho00112/python-livereload/archive/refs/heads/master.zip
 python-minifier==2.8.0
 autoflake==1.6.1
 Flask==2.2.2


### PR DESCRIPTION
Closes https://github.com/pyfyre/pyfyre/issues/36.
This is until livereload developers accept my pull request at https://github.com/lepture/python-livereload/pull/271.